### PR TITLE
Aggregation settings defect fixes

### DIFF
--- a/datamodel.py
+++ b/datamodel.py
@@ -54,6 +54,7 @@ class DataModel:
         if type(select) is str:
             tempindex = self.getcolumnindex(select)
         temp = self.getdatacolumn(tempindex)
+
         return temp.values.tolist()
 
     def getcolumnindex(self, name):  # returns numerical index of named column
@@ -70,5 +71,17 @@ class DataModel:
 
     def getdatasetforfeature(self, time, feature):
         # Create list of data points for the given
-        datapoints = list(map(lambda x, y: DataPoint(x, y), self.getcolumnaslist(time), self.getcolumnaslist(feature)))
+        y_data = self.getcolumnaslist(feature)
+        
+        def on_wrist_converter_callback(val):
+            if val:
+                return 1
+            else:
+                return 0
+                
+        if feature == "On Wrist":
+            y_data = map(on_wrist_converter_callback, y_data)
+
+        datapoints = list(map(lambda x, y: DataPoint(x, y), self.getcolumnaslist(time), y_data))
         return DataSet(feature, datapoints)
+

--- a/dataset.py
+++ b/dataset.py
@@ -7,7 +7,8 @@ from matplotlib.figure import Figure
 
 
 class Interval(Enum):
-    ONE_MINUTE = 1
+    # ONE_MINUTE = 1
+    TWO_MINUTES = 1
     THIRTY_MINUTES = 2
     ONE_HOUR = 3
     THREE_HOURS = 4
@@ -140,8 +141,10 @@ class AggregatedDataSet:
     @staticmethod
     def get_interval_string(variant):
         match variant.name:
-            case "ONE_MINUTE":
-                return "1 min"
+            # case "ONE_MINUTE":
+            #     return "1 min"
+            case "TWO_MINUTES":
+                return "2 min"
             case "THIRTY_MINUTES":
                 return "30 min"
             case "ONE_HOUR":
@@ -166,9 +169,9 @@ class AggregatedDataSet:
             case "MEDIAN":
                 return df.median()
             case "VARIANCE":
-                return df.var()
+                return df.var(ddof=0)
             case "STD":
-                return df.std()
+                return df.std(ddof=0)
 
     def update_agg_settings(self, setting_type, setting_value):
         if setting_type == "interval":
@@ -177,7 +180,8 @@ class AggregatedDataSet:
                 metric_setting = self.aggregationSettings.metric
             self.master.time_series.plot_selected_group(setting_value, metric_setting)
         elif setting_type == "metric":
-            interval_setting = Interval.ONE_MINUTE
+            # interval_setting = Interval.ONE_MINUTE
+            interval_setting = Interval.TWO_MINUTES
             if self.aggregationSettings.interval is not None:
                 interval_setting = self.aggregationSettings.interval
             self.master.time_series.plot_selected_group(interval_setting, setting_value)


### PR DESCRIPTION
Implemented fix for On Wrist not showing. For the other issue with the aggregation settings, I wasn't able to replicate the issue with Min/Max after trying each combination of interval with both Min and Max and at the same time adjusting the slider. As far as the Variance and STD aggregation settings, I found out that we needed to put the ddof option to 0 to be able to view any data for those metrics. For the 1 min option it was just showing a straight line, which I think might be due the data points being recorded once a minute, but I'm not sure. To fix this I removed the 1 minute option from the interval, and replaced it with a 2 minute option. It seems that any value over 1 generates visible data.